### PR TITLE
Add admin database backup endpoint and panel button

### DIFF
--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -19,8 +19,10 @@
         .btn, button { padding: 8px 15px; border: none; border-radius: 4px; color: white; cursor: pointer; text-decoration: none; font-size: 14px; display: inline-block; text-align: center; }
         .btn-edit { background-color: #ffc107; color: #212529;}
         .btn-logout { background-color: #dc3545; float: right;}
+        .btn-backup { background-color: #17a2b8; margin-right: 10px; }
         .table-container { overflow-x: auto; }
         .header-controls { display: flex; justify-content: space-between; align-items: center; }
+        .header-actions { display: flex; align-items: center; gap: 10px; }
         /* Estilos para el estado en la tabla */
         .status { padding: 5px 10px; border-radius: 4px; color: white; text-align: center; font-weight: bold; }
         .status-confirmado { background-color: #28a745; }
@@ -32,9 +34,12 @@
 <div class="container">
     <div class="header-controls">
         <h1>Panel de Invitados</h1>
-        <form action="/admin-logout" method="get">
-            <button class="btn-logout">Cerrar Sesión</button>
-        </form>
+        <div class="header-actions">
+            <a class="btn btn-backup" href="/admin/backup">Descargar respaldo</a>
+            <form action="/admin-logout" method="get">
+                <button class="btn-logout">Cerrar Sesión</button>
+            </form>
+        </div>
     </div>
 
     <div class="stats">


### PR DESCRIPTION
## Summary
- add an fs.promises alias and create an authenticated `/admin/backup` route that produces timestamped database copies
- ensure a backups directory exists and stream the generated file for download
- expose the new backup capability via a button in the admin invitados panel

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dae6eb2ebc832ba7a2d2ae0169c983