### PR TITLE
Enable WAL mode and document backup requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ npm run prerender:svg
 El script `npm run prerender:svg` analiza cada archivo `assets/*.svg`, limpia los nodos con `svgson` y genera versiones PNG y WebP en `assets/prerendered/`. Se recomienda ejecutar este comando como parte del flujo de compilación o despliegue, antes de iniciar el servidor en el entorno de producción.
 
 Tras ejecutar el comando, el servidor (`app.js`) entregará automáticamente las versiones WebP/PNG pre-generadas cuando el encabezado `Accept` del cliente lo permita, manteniendo los SVG originales como alternativa de compatibilidad.
+
+## Respaldos de la base de datos
+
+La aplicación habilita el modo [`WAL`](https://www.sqlite.org/wal.html) en SQLite para mejorar el rendimiento y la concurrencia. Al generar respaldos mientras el servidor está en ejecución, basta con copiar el archivo `database.db`; SQLite se encarga de mantener la consistencia del archivo aun cuando exista un archivo `-wal` temporal.

--- a/app.js
+++ b/app.js
@@ -10,7 +10,23 @@ const compression = require("compression");
 
 const app = express();
 const upload = multer({ dest: "uploads/" });
-const db = new sqlite3.Database("database.db");
+const db = new sqlite3.Database("database.db", (err) => {
+    if (err) {
+        console.error("Error al abrir la base de datos:", err);
+    }
+});
+
+db.exec("PRAGMA journal_mode=WAL;", (err) => {
+    if (err) {
+        console.error("No se pudo habilitar el modo WAL:", err);
+    }
+});
+
+try {
+    db.configure("busyTimeout", 5000);
+} catch (error) {
+    console.error("No se pudo configurar el busyTimeout de la base de datos:", error);
+}
 const isProduction = process.env.NODE_ENV === "production";
 
 const CLAVE_CORRECTA = "Victoria2025**";


### PR DESCRIPTION
## Summary
- enable WAL mode for SQLite and configure a busy timeout with error logging when initialization fails
- document that backups should copy the main database file while WAL mode is active

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dae8a631e4832b9b7da2e7b0d4de73