### PR TITLE
Add admin flow to manually create guests

### DIFF
--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -18,6 +18,7 @@
         tr:nth-child(even) { background-color: #f8f9fa; }
         .btn, button { padding: 8px 15px; border: none; border-radius: 4px; color: white; cursor: pointer; text-decoration: none; font-size: 14px; display: inline-block; text-align: center; }
         .btn-edit { background-color: #ffc107; color: #212529;}
+        .btn-new { background-color: #28a745; }
         .btn-logout { background-color: #dc3545; float: right;}
         .btn-backup { background-color: #17a2b8; margin-right: 10px; }
         .table-container { overflow-x: auto; }
@@ -35,6 +36,7 @@
     <div class="header-controls">
         <h1>Panel de Invitados</h1>
         <div class="header-actions">
+            <a class="btn btn-new" href="/admin/invitado/nuevo">Nuevo invitado</a>
             <a class="btn btn-backup" href="/admin/backup">Descargar respaldo</a>
             <form action="/admin-logout" method="get">
                 <button class="btn-logout">Cerrar Sesión</button>

--- a/views/admin_nuevo_invitado.ejs
+++ b/views/admin_nuevo_invitado.ejs
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Nuevo Invitado</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; padding: 20px; background-color: #f4f7f9; }
+        .container { max-width: 600px; margin: 20px auto; background: white; padding: 30px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.05); }
+        h1 { color: #007bff; text-align: center; }
+        .form-group { margin-bottom: 20px; }
+        label { display: block; margin-bottom: 8px; font-weight: bold; }
+        input { width: 100%; padding: 10px; border-radius: 4px; border: 1px solid #ccc; box-sizing: border-box; font-size: 16px; }
+        button[type="submit"] { background-color: #28a745; color: white; width: 100%; padding: 12px 20px; border: none; border-radius: 4px; cursor: pointer; font-size: 16px; }
+        .cancel-link { display: block; text-align: center; margin-top: 15px; color: #007bff; text-decoration: none; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Nuevo Invitado</h1>
+    <form action="/admin/invitado/crear" method="POST">
+        <div class="form-group">
+            <label for="nombre">Nombre</label>
+            <input type="text" id="nombre" name="nombre" required>
+        </div>
+        <div class="form-group">
+            <label for="apellido">Apellido</label>
+            <input type="text" id="apellido" name="apellido">
+        </div>
+        <div class="form-group">
+            <label for="cantidad">Invitados (Total)</label>
+            <input type="number" id="cantidad" name="cantidad" required min="0" value="1">
+        </div>
+        <button type="submit">Guardar</button>
+    </form>
+    <a href="/admin/invitados" class="cancel-link">Cancelar y volver al listado</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add authenticated routes to render the manual guest creation form and persist new guests with normalized ids
- create an admin template for adding guests and link it from the guest list view so the new records appear after saving

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68daeb559d6c832b8d23fcd5e56dd939