### PR TITLE
Actualizar flujo de confirmación en invitación

### DIFF
--- a/views/invitacion.ejs
+++ b/views/invitacion.ejs
@@ -330,6 +330,42 @@
             color: var(--color-dark);
         }
 
+        .card .alert {
+            background: rgba(255, 255, 255, 0.65);
+            border: 1px solid rgba(112, 160, 200, 0.55);
+            border-radius: 12px;
+            padding: 14px 18px;
+            margin-bottom: 20px;
+            color: #2f3d5c;
+            font-weight: 500;
+            line-height: 1.4;
+        }
+
+        .card .alert-success {
+            background: rgba(112, 160, 200, 0.18);
+            border-color: rgba(66, 116, 155, 0.45);
+            color: #1f3c5c;
+        }
+
+        .card .alert-info {
+            background: rgba(255, 255, 255, 0.55);
+        }
+
+        .card .respuesta-resumen {
+            background: rgba(255, 255, 255, 0.55);
+            border-radius: 12px;
+            padding: 20px 22px;
+            margin-top: 20px;
+            color: #2f3d5c;
+            line-height: 1.5;
+        }
+
+        .card .respuesta-resumen .nota {
+            margin-top: 12px;
+            font-size: 0.95em;
+            opacity: 0.85;
+        }
+
         .form-group {
             margin-bottom: 25px;
         }
@@ -781,30 +817,47 @@
                 <h3>¡Hola, <%= invitado.nombre %><% if (invitado.apellido) { %> <%= invitado.apellido %><% } %>!</h3>                <p>Tu invitación es válida para <strong><%= invitado.cantidad %> persona(s)</strong>.</p>
                 <p>Por favor, confirma tu asistencia antes del 10 de Noviembre.</p>
 
-                <form action="/confirmar/<%= invitado.id %>" method="POST">
+                <% if (alerta) { %>
+                    <div class="alert <%= alerta.tipo === 'exito' ? 'alert-success' : 'alert-info' %>"><%= alerta.mensaje %></div>
+                <% } %>
 
-                    <div class="form-group decision-buttons">
-                        <label>
-                            <input type="radio" id="asistencia_si" name="decision" value="confirmado" checked onchange="toggleCantidad(true)">
-                            <span><i class="fas fa-check"></i> Sí, asistiré</span>
-                        </label>
-                        <label>
-                            <input type="radio" id="asistencia_no" name="decision" value="rechazado" onchange="toggleCantidad(false)">
-                            <span><i class="fas fa-times"></i> No podré asistir</span>
-                        </label>
+                <% if (bloquearFormulario) { %>
+                    <div class="respuesta-resumen">
+                        <% if (invitado.estado === 'confirmado') { %>
+                            <p><strong>¡Gracias!</strong> Ya registramos que asistirán <strong><%= invitado.confirmados || 0 %></strong> persona(s).</p>
+                        <% } else if (invitado.estado === 'rechazado') { %>
+                            <p>Registramos que no podrán acompañarnos en la celebración.</p>
+                        <% } else { %>
+                            <p>Ya registramos tu respuesta para esta invitación.</p>
+                        <% } %>
+                        <p class="nota">Si necesitás actualizar algún dato, por favor contactá a los organizadores.</p>
                     </div>
+                <% } else { %>
+                    <form action="/confirmar/<%= invitado.id %>" method="POST">
 
-                    <div id="cantidad-group" class="form-group">
-                        <label for="cantidad">¿Cuántos de los <%= invitado.cantidad %> asistirán?</label>
-                        <select id="cantidad" name="confirmados" required>
-                            <% for(let i = 1; i <= invitado.cantidad; i++) { %>
-                                <option value="<%= i %>"><%= i %></option>
-                            <% } %>
-                        </select>
-                    </div>
+                        <div class="form-group decision-buttons">
+                            <label>
+                                <input type="radio" id="asistencia_si" name="decision" value="confirmado" checked onchange="toggleCantidad(true)">
+                                <span><i class="fas fa-check"></i> Sí, asistiré</span>
+                            </label>
+                            <label>
+                                <input type="radio" id="asistencia_no" name="decision" value="rechazado" onchange="toggleCantidad(false)">
+                                <span><i class="fas fa-times"></i> No podré asistir</span>
+                            </label>
+                        </div>
 
-                    <button type="submit">Enviar Confirmación</button>
-                </form>
+                        <div id="cantidad-group" class="form-group">
+                            <label for="cantidad">¿Cuántos de los <%= invitado.cantidad %> asistirán?</label>
+                            <select id="cantidad" name="confirmados" required>
+                                <% for(let i = 1; i <= invitado.cantidad; i++) { %>
+                                    <option value="<%= i %>"><%= i %></option>
+                                <% } %>
+                            </select>
+                        </div>
+
+                        <button type="submit">Enviar Confirmación</button>
+                    </form>
+                <% } %>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Ajusta la ruta GET de confirmación para renderizar siempre la invitación con alertas contextuales y bloqueo cuando corresponda
- Actualiza la ruta POST para redirigir a la misma invitación, mostrar avisos en sitio y evitar el uso de la página de agradecimiento
- Modifica la vista de invitación con estilos y condicionales que muestran mensajes de estado y ocultan el formulario cuando la respuesta ya fue registrada

## Testing
- No se agregaron pruebas automatizadas; el proyecto no define un comando de pruebas


------
https://chatgpt.com/codex/tasks/task_e_68daec121f58832b9aefb004b7af5f0b