### PR TITLE
Add confirmation links to admin guest list

### DIFF
--- a/app.js
+++ b/app.js
@@ -394,13 +394,15 @@ app.get("/admin/invitados", checkAdmin, (req, res) => {
         });
         const pendientes = rows.filter(r => r.estado === 'pendiente').length;
         const rechazados = rows.filter(r => r.estado === 'rechazado').length;
+        const baseUrl = req.protocol + "://" + req.get("host");
 
         res.render("admin_invitados", {
             invitados: rows,
             totalInvitados,
             confirmados,
             pendientes,
-            rechazados
+            rechazados,
+            baseUrl
         });
     });
 });

--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -29,6 +29,8 @@
         .status-confirmado { background-color: #28a745; }
         .status-pendiente { background-color: #6c757d; }
         .status-rechazado { background-color: #dc3545; }
+        .link-cell { word-break: break-all; font-size: 12px; }
+        .link-cell a { color: #007bff; }
     </style>
 </head>
 <body>
@@ -75,6 +77,7 @@
                 <th>Invitados (Grupo)</th>
                 <th>Asistirán</th>
                 <th>Estado</th>
+                <th>Link</th>
                 <th>Acciones</th>
             </tr>
             </thead>
@@ -89,6 +92,9 @@
                         <span class="status status-<%= invitado.estado.toLowerCase() %>">
                             <%= invitado.estado %>
                         </span>
+                    </td>
+                    <td class="link-cell">
+                        <a target="_blank" href="<%= baseUrl %>/confirmar/<%= invitado.id %>"><%= baseUrl %>/confirmar/<%= invitado.id %></a>
                     </td>
                     <td>
                         <a href="/admin/invitado/editar/<%= invitado.id %>" class="btn btn-edit">Editar</a>


### PR DESCRIPTION
## Summary
- expose the request base URL to the admin guest list view
- display a confirmation link column with styling to keep long URLs readable

## Testing
- no tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68db2922cad4832b9b236204a8d695b6