### PR TITLE
Fix SVGO cleanupIds plugin name

### DIFF
--- a/scripts/prerender-svg.js
+++ b/scripts/prerender-svg.js
@@ -18,7 +18,7 @@ function optimizeSvg(svgContent, filePath) {
       floatPrecision: 2,
       plugins: [
         'removeDoctype','removeXMLProcInst','removeComments','removeMetadata','removeEditorsNSData',
-        'cleanupAttrs','convertStyleToAttrs','minifyStyles','cleanupIDs','removeUselessDefs','collapseGroups',
+        'cleanupAttrs','convertStyleToAttrs','minifyStyles','cleanupIds','removeUselessDefs','collapseGroups',
         'convertShapeToPath','convertPathData','mergePaths','removeEmptyContainers','removeEmptyText',
         { name: 'removeDimensions', active: true },
         { name: 'sortAttrs', active: true },


### PR DESCRIPTION
## Summary
- update the prerender script to use the SVGO 3 plugin identifier `cleanupIds`

## Testing
- npm run optimize:svg *(interrupted after confirming the SVGO warning was gone because large rasterization work was taking too long)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbf68b990832bad669c91bc27ea13