### PR TITLE
Allow Sharp to rasterize large SVGs

### DIFF
--- a/scripts/prerender-svg.js
+++ b/scripts/prerender-svg.js
@@ -62,7 +62,7 @@ async function processSvgFile(fileName) {
     return { fileName, skipped: true };
   }
 
-  const img = sharp(Buffer.from(optimized));
+  const img = sharp(Buffer.from(optimized), { unlimited: true });
   await Promise.all([
     img.clone().png({ compressionLevel: 9, progressive: true }).toFile(path.join(OUTPUT_DIR, `${baseName}.png`)),
     img.clone().webp({ quality: 82 }).toFile(path.join(OUTPUT_DIR, `${baseName}.webp`)),


### PR DESCRIPTION
## Summary
- instantiate Sharp with the `unlimited` option when prerendering SVG assets so large files can be rasterized

## Testing
- npm run optimize:svg

------
https://chatgpt.com/codex/tasks/task_e_68dbc22d51f0832b936de6acb67e7e72