### PR TITLE
Fix confirmation update for MySQL compatibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -352,11 +352,11 @@ app.post("/confirmar/:id", async (req, res) => {
         }
 
         const result = await db.query(
-            "UPDATE invitados SET estado = ?, confirmados = ? WHERE id = ? AND estado = 'pendiente' RETURNING id",
+            "UPDATE invitados SET estado = ?, confirmados = ? WHERE id = ? AND estado = 'pendiente'",
             [decision, confirmadosInt, id]
         );
 
-        if (result.rowCount === 0) {
+        if (!result || result.affectedRows === 0) {
             return res.redirect(`/confirmar/${id}`);
         }
 


### PR DESCRIPTION
## Summary
- remove the RETURNING clause from the confirmation update so the statement works with MySQL
- use the ResultSetHeader.affectedRows value to decide whether to show the success redirect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc9b18ea60832b9e1c0a58d9abc55d