### PR TITLE
Fix admin backup route to use mysql2 query result array

### DIFF
--- a/app.js
+++ b/app.js
@@ -135,7 +135,7 @@ app.get("/admin", checkAdmin, (req, res) => {
 
 app.get("/admin/backup", checkAdmin, async (req, res) => {
     try {
-        const { rows } = await db.query("SELECT * FROM invitados ORDER BY nombre");
+        const rows = await db.query("SELECT * FROM invitados ORDER BY nombre");
 
         await fsp.mkdir(path.join(__dirname, "backups"), { recursive: true });
 


### PR DESCRIPTION
## Summary
- update the `/admin/backup` handler to use the array returned directly from `mysql2` so backups serialize correctly

## Testing
- not run (no tests available)

------
https://chatgpt.com/codex/tasks/task_e_68dc9c79ffa0832b984788e1c52147f7