### PR TITLE
Evita superposición de mensajes en confirmación

### DIFF
--- a/app.js
+++ b/app.js
@@ -258,7 +258,7 @@ app.get("/confirmar/:id", async (req, res) => {
             let mensajeExito;
             if (invitado.estado === "confirmado") {
                 const cantidadConfirmada = invitado.confirmados || 0;
-                mensajeExito = `¡Gracias! Registramos que asistirán ${cantidadConfirmada} persona(s).`;
+                mensajeExito = `¡Gracias! Confirmamos tu asistencia para ${cantidadConfirmada} persona(s).`;
             } else if (invitado.estado === "rechazado") {
                 mensajeExito = "Registramos que no podrán acompañarnos. ¡Gracias por avisarnos!";
             } else {
@@ -268,10 +268,13 @@ app.get("/confirmar/:id", async (req, res) => {
             alerta = { tipo: "exito", mensaje: mensajeExito };
         }
 
+        const mostrarResumen = bloquearFormulario && !alerta;
+
         res.render("invitacion", {
             invitado,
             bloquearFormulario,
-            alerta
+            alerta,
+            mostrarResumen
         });
     } catch (error) {
         console.error("Error al obtener invitado:", error);
@@ -302,13 +305,24 @@ app.post("/confirmar/:id", async (req, res) => {
         }
 
         if (invitado.estado !== "pendiente") {
+            let mensajeInfo;
+            if (invitado.estado === "confirmado") {
+                const cantidadConfirmada = invitado.confirmados || 0;
+                mensajeInfo = `Ya registramos que asistirán ${cantidadConfirmada} persona(s). Si necesitás actualizar algún dato, contactá a los organizadores.`;
+            } else if (invitado.estado === "rechazado") {
+                mensajeInfo = "Ya registramos que no podrán acompañarnos. Si necesitás actualizar algún dato, contactá a los organizadores.";
+            } else {
+                mensajeInfo = "Ya registramos tu respuesta para esta invitación. Si necesitás actualizar algún dato, contactá a los organizadores.";
+            }
+
             return res.status(409).render("invitacion", {
                 invitado,
                 bloquearFormulario: true,
                 alerta: {
                     tipo: "info",
-                    mensaje: "Ya registramos tu respuesta. Si necesitás hacer un cambio, contactá a los organizadores."
-                }
+                    mensaje: mensajeInfo
+                },
+                mostrarResumen: false
             });
         }
 

--- a/views/invitacion.ejs
+++ b/views/invitacion.ejs
@@ -883,18 +883,18 @@
                         <div class="alert <%= alerta.tipo === 'exito' ? 'alert-success' : 'alert-info' %>"><%= alerta.mensaje %></div>
                     <% } %>
 
-                    <% if (bloquearFormulario) { %>
+                    <% if (mostrarResumen) { %>
                         <div class="respuesta-resumen">
                             <% if (invitado.estado === 'confirmado') { %>
-                                <p><strong>¡Gracias!</strong> Ya registramos que asistirán <strong><%= invitado.confirmados || 0 %></strong> persona(s).</p>
+                                <p>Confirmaste que asistirán <strong><%= invitado.confirmados || 0 %></strong> persona(s).</p>
                             <% } else if (invitado.estado === 'rechazado') { %>
-                                <p>Registramos que no podrán acompañarnos en la celebración.</p>
+                                <p>Registraste que no podrán acompañarnos en la celebración.</p>
                             <% } else { %>
-                                <p>Ya registramos tu respuesta para esta invitación.</p>
+                                <p>Registramos tu respuesta para esta invitación.</p>
                             <% } %>
                             <p class="nota">Si necesitás actualizar algún dato, por favor contactá a los organizadores.</p>
                         </div>
-                    <% } else { %>
+                    <% } else if (!bloquearFormulario) { %>
                         <form action="/confirmar/<%= invitado.id %>" method="POST">
 
                             <div class="form-group decision-buttons">


### PR DESCRIPTION
## Summary
- calcula un flag `mostrarResumen` en la ruta de confirmación y lo envía a la vista para controlar la tarjeta de resumen
- ajusta los mensajes de éxito e informativos según el estado registrado para evitar duplicados
- actualiza la vista de invitación para mostrar el resumen solo cuando corresponde y con textos coherentes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd2d44b924832b87f2290f3a395d88