### PR TITLE
Add explicit admin route redirect to invitados listing

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,9 +100,9 @@ app.get("/estado", async (req, res) => {
     }
 });
 
-// app.get("/admin", checkAdmin, (req, res) => {
-//     res.sendFile(path.join(__dirname, "public", "index.html"));
-// });
+app.get("/admin", checkAdmin, (req, res) => {
+    res.redirect("/admin/invitados");
+});
 
 app.get("/admin/backup", checkAdmin, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- add a protected /admin route that redirects to the invitados listing when accessed

## Testing
- node app.js *(fails: database connection is unreachable in the current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2fda2500832bb8e810a3476c7054