### PR TITLE
Add admin guest deletion endpoint and UI control

### DIFF
--- a/app.js
+++ b/app.js
@@ -378,13 +378,16 @@ app.get("/admin/invitados", checkAdmin, async (req, res) => {
         const rechazados = invitados.filter(r => r.estado === "rechazado").length;
         const baseUrl = req.protocol + "://" + req.get("host");
 
+        const mensajeExito = req.query.exito === "1" ? "Invitado eliminado correctamente." : null;
+
         res.render("admin_invitados", {
             invitados,
             totalInvitados,
             confirmados,
             pendientes,
             rechazados,
-            baseUrl
+            baseUrl,
+            mensajeExito
         });
     } catch (error) {
         console.error("Error al obtener invitados:", error);
@@ -467,6 +470,32 @@ app.post("/admin/invitado/actualizar/:id", checkAdmin, async (req, res) => {
     } catch (error) {
         console.error("Error al actualizar invitado:", error);
         res.status(500).send("Error al actualizar el invitado.");
+    }
+});
+
+
+app.post("/admin/invitado/eliminar/:id", checkAdmin, async (req, res) => {
+    const { id } = req.params;
+
+    try {
+        const resultado = await db.query("DELETE FROM invitados WHERE id = ?", [id]);
+
+        if (resultado && resultado.affectedRows === 0) {
+            return res.status(404).render("mensaje", {
+                titulo: "Invitado no encontrado",
+                tituloH1: "No se encontró el invitado",
+                mensaje: "El invitado que intentás eliminar no existe."
+            });
+        }
+
+        res.redirect("/admin/invitados?exito=1");
+    } catch (error) {
+        console.error("Error al eliminar invitado:", error);
+        res.status(500).render("mensaje", {
+            titulo: "Error al eliminar invitado",
+            tituloH1: "No se pudo eliminar el invitado",
+            mensaje: "Ocurrió un problema al eliminar el invitado. Intentá nuevamente."
+        });
     }
 });
 

--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -21,6 +21,7 @@
         .btn-new { background-color: #28a745; }
         .btn-logout { background-color: #dc3545; float: right;}
         .btn-backup { background-color: #17a2b8; margin-right: 10px; }
+        .btn-delete { background-color: #dc3545; }
         .table-container { overflow-x: auto; }
         .header-controls { display: flex; justify-content: space-between; align-items: center; }
         .header-actions { display: flex; align-items: center; gap: 10px; }
@@ -31,6 +32,20 @@
         .status-rechazado { background-color: #dc3545; }
         .link-cell { word-break: break-all; font-size: 12px; }
         .link-cell a { color: #007bff; }
+        .alert {
+            margin: 20px 0;
+            padding: 15px;
+            border-radius: 6px;
+            background-color: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        .action-buttons {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
     </style>
 </head>
 <body>
@@ -45,6 +60,10 @@
             </form>
         </div>
     </div>
+
+    <% if (mensajeExito) { %>
+        <div class="alert"><%= mensajeExito %></div>
+    <% } %>
 
     <div class="stats">
         <div class="stat-card">
@@ -97,7 +116,12 @@
                         <a target="_blank" href="<%= baseUrl %>/confirmar/<%= invitado.id %>"><%= baseUrl %>/confirmar/<%= invitado.id %></a>
                     </td>
                     <td>
-                        <a href="/admin/invitado/editar/<%= invitado.id %>" class="btn btn-edit">Editar</a>
+                        <div class="action-buttons">
+                            <a href="/admin/invitado/editar/<%= invitado.id %>" class="btn btn-edit">Editar</a>
+                            <form action="/admin/invitado/eliminar/<%= invitado.id %>" method="POST" onsubmit="return confirm('¿Seguro que querés eliminar a <%= invitado.nombre %> <%= invitado.apellido || '' %>? Esta acción no se puede deshacer.');">
+                                <button type="submit" class="btn btn-delete">Eliminar</button>
+                            </form>
+                        </div>
                     </td>
                 </tr>
             <% }); %>


### PR DESCRIPTION
## Summary
- add a protected endpoint to delete guests by id and handle missing records
- show success feedback on the guest listing after deletions
- add a delete action with confirmation to each guest row in the admin table

## Testing
- not run (tests not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd311669dc832ba601aac66eb1c9fc