### PR TITLE
Add admin import form and status feedback

### DIFF
--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -22,9 +22,10 @@
         .btn-logout { background-color: #dc3545; float: right;}
         .btn-backup { background-color: #17a2b8; margin-right: 10px; }
         .btn-delete { background-color: #dc3545; }
+        .btn-import { background-color: #6610f2; }
         .table-container { overflow-x: auto; }
         .header-controls { display: flex; justify-content: space-between; align-items: center; }
-        .header-actions { display: flex; align-items: center; gap: 10px; }
+        .header-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
         /* Estilos para el estado en la tabla */
         .status { padding: 5px 10px; border-radius: 4px; color: white; text-align: center; font-weight: bold; }
         .status-confirmado { background-color: #28a745; }
@@ -32,19 +33,33 @@
         .status-rechazado { background-color: #dc3545; }
         .link-cell { word-break: break-all; font-size: 12px; }
         .link-cell a { color: #007bff; }
-        .alert {
-            margin: 20px 0;
-            padding: 15px;
-            border-radius: 6px;
-            background-color: #d4edda;
-            color: #155724;
-            border: 1px solid #c3e6cb;
-        }
+        .alert { margin: 20px 0; padding: 15px; border-radius: 6px; border: 1px solid transparent; }
+        .alert-exito { background-color: #d4edda; color: #155724; border-color: #c3e6cb; }
+        .alert-error { background-color: #f8d7da; color: #721c24; border-color: #f5c6cb; }
         .action-buttons {
             display: flex;
             gap: 8px;
             flex-wrap: wrap;
             align-items: center;
+        }
+        .import-form {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            background: #f8f9fa;
+            padding: 8px 12px;
+            border-radius: 6px;
+            border: 1px solid #dee2e6;
+        }
+        .import-form input[type="file"] {
+            font-size: 13px;
+        }
+        @media (max-width: 600px) {
+            .header-controls { flex-direction: column; align-items: flex-start; gap: 16px; }
+            .header-actions { width: 100%; justify-content: flex-start; }
+            .import-form { width: 100%; flex-wrap: wrap; }
+            .import-form input[type="file"] { flex: 1 1 100%; }
+            .import-form button { width: 100%; }
         }
     </style>
 </head>
@@ -53,6 +68,11 @@
     <div class="header-controls">
         <h1>Panel de Invitados</h1>
         <div class="header-actions">
+            <form class="import-form" action="/upload" method="post" enctype="multipart/form-data">
+                <label for="excel" style="font-weight: 600; font-size: 13px;">Importar listado</label>
+                <input type="file" id="excel" name="excel" accept=".xlsx,.xls,.csv">
+                <button type="submit" class="btn btn-import">Importar</button>
+            </form>
             <a class="btn btn-new" href="/admin/invitado/nuevo">Nuevo invitado</a>
             <a class="btn btn-backup" href="/admin/backup">Descargar respaldo</a>
             <form action="/admin-logout" method="get">
@@ -61,8 +81,12 @@
         </div>
     </div>
 
+    <% if (mensajeImportacion) { %>
+        <div class="alert alert-<%= mensajeImportacion.tipo %>"><%= mensajeImportacion.texto %></div>
+    <% } %>
+
     <% if (mensajeExito) { %>
-        <div class="alert"><%= mensajeExito %></div>
+        <div class="alert alert-exito"><%= mensajeExito %></div>
     <% } %>
 
     <div class="stats">


### PR DESCRIPTION
## Summary
- add an Excel import form to the admin guests panel while keeping access to backups and manual creation
- surface success and error alerts in the panel after an import attempt
- redirect the existing upload endpoint with status flags to drive the new UI feedback

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68dd31ff0f20832b87c12fd6619673bd