### PR TITLE
Refactor admin invitados view layout

### DIFF
--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -5,12 +5,100 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Panel de Invitados</title>
     <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif; padding: 20px; background-color: #f4f7f9; color: #333; margin: 0;}
-        .container { max-width: 1200px; margin: 0 auto; background: white; padding: 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.05); }
-        h1 { color: #007bff; text-align: center; margin-bottom: 30px; }
+        :root {
+            color-scheme: light;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            background-color: #f4f7f9;
+            color: #333;
+            margin: 0;
+        }
+        .admin-shell {
+            display: flex;
+            min-height: 100vh;
+        }
+        .admin-sidebar {
+            background: #0d1b2a;
+            color: #fff;
+            padding: 32px 24px;
+            width: 260px;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+            position: sticky;
+            top: 0;
+            height: 100vh;
+        }
+        .admin-sidebar h1 {
+            font-size: 1.5rem;
+            margin: 0;
+            color: #fff;
+        }
+        .admin-nav {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .admin-nav a {
+            color: #cfe0ff;
+            text-decoration: none;
+            font-weight: 600;
+            padding: 10px 14px;
+            border-radius: 6px;
+            transition: background 0.2s ease, color 0.2s ease;
+        }
+        .admin-nav a:hover,
+        .admin-nav a:focus {
+            background: rgba(255, 255, 255, 0.12);
+            color: #fff;
+            outline: none;
+        }
+        .admin-nav a.is-active {
+            background: #1b263b;
+            color: #fff;
+        }
+        .admin-sidebar .sidebar-actions {
+            margin-top: auto;
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+        .admin-content {
+            flex: 1;
+            padding: 32px;
+            display: flex;
+            justify-content: center;
+        }
+        .container {
+            max-width: 1200px;
+            width: 100%;
+            background: white;
+            padding: 32px;
+            border-radius: 16px;
+            box-shadow: 0 2px 20px rgba(13, 27, 42, 0.08);
+        }
+        .admin-section {
+            scroll-margin-top: 32px;
+            padding-top: 8px;
+            margin-bottom: 40px;
+        }
+        .admin-section h2 {
+            margin-top: 0;
+            color: #0d1b2a;
+        }
+        .admin-section:target,
+        .admin-section.is-active {
+            animation: sectionHighlight 0.4s ease;
+        }
+        @keyframes sectionHighlight {
+            from { box-shadow: 0 0 0 rgba(13, 110, 253, 0); }
+            to { box-shadow: 0 0 0 rgba(13, 110, 253, 0); }
+        }
         .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 20px; margin-bottom: 30px; }
         .stat-card { background: #e9ecef; padding: 20px; border-radius: 8px; text-align: center; }
-        .stat-card h2 { margin: 0 0 10px 0; font-size: 1em; color: #555; text-transform: uppercase; }
+        .stat-card h2,
+        .stat-card h3 { margin: 0 0 10px 0; font-size: 1em; color: #555; text-transform: uppercase; }
         .stat-card p { margin: 0; font-size: 2.2em; font-weight: bold; }
         table { width: 100%; border-collapse: collapse; margin-top: 20px; font-size: 14px; }
         th, td { padding: 12px 15px; border: 1px solid #ddd; text-align: left; }
@@ -19,13 +107,13 @@
         .btn, button { padding: 8px 15px; border: none; border-radius: 4px; color: white; cursor: pointer; text-decoration: none; font-size: 14px; display: inline-block; text-align: center; }
         .btn-edit { background-color: #ffc107; color: #212529;}
         .btn-new { background-color: #28a745; }
-        .btn-logout { background-color: #dc3545; float: right;}
+        .btn-logout { background-color: #dc3545; }
         .btn-backup { background-color: #17a2b8; margin-right: 10px; }
         .btn-delete { background-color: #dc3545; }
         .btn-import { background-color: #6610f2; }
         .table-container { overflow-x: auto; }
-        .header-controls { display: flex; justify-content: space-between; align-items: center; }
-        .header-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-end; }
+        .header-controls { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px; }
+        .header-actions { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; justify-content: flex-start; }
         .search-form {
             display: flex;
             align-items: center;
@@ -41,7 +129,6 @@
             border-radius: 4px;
             font-size: 14px;
         }
-        /* Estilos para el estado en la tabla */
         .status { padding: 5px 10px; border-radius: 4px; color: white; text-align: center; font-weight: bold; }
         .status-confirmado { background-color: #28a745; }
         .status-pendiente { background-color: #6c757d; }
@@ -72,7 +159,36 @@
         .btn-secondary { background-color: #6c757d; }
         .btn-search { background-color: #007bff; }
         .alert-info { background-color: #d1ecf1; color: #0c5460; border-color: #bee5eb; }
+        @media (max-width: 960px) {
+            .admin-shell {
+                flex-direction: column;
+            }
+            .admin-sidebar {
+                position: static;
+                width: 100%;
+                height: auto;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+            }
+            .admin-content {
+                padding: 24px 16px 48px;
+            }
+            .container {
+                padding: 24px 20px;
+            }
+            .admin-nav {
+                flex-direction: row;
+                flex-wrap: wrap;
+                gap: 8px;
+            }
+            .admin-nav a {
+                flex: 1 1 45%;
+                text-align: center;
+            }
+        }
         @media (max-width: 600px) {
+            .admin-nav a {
+                flex: 1 1 100%;
+            }
             .header-controls { flex-direction: column; align-items: flex-start; gap: 16px; }
             .header-actions { width: 100%; justify-content: flex-start; }
             .import-form { width: 100%; flex-wrap: wrap; }
@@ -85,104 +201,163 @@
     </style>
 </head>
 <body>
-<div class="container">
-    <div class="header-controls">
+<div class="admin-shell">
+    <aside class="admin-sidebar">
         <h1>Panel de Invitados</h1>
-        <div class="header-actions">
-            <form class="search-form" action="/admin/invitados" method="get">
-                <label for="buscar" style="font-weight: 600; font-size: 13px;">Buscar</label>
-                <input id="buscar" type="text" name="q" placeholder="Nombre o apellido" value="<%= termino || '' %>">
-                <button type="submit" class="btn btn-search">Buscar</button>
-                <a class="btn btn-secondary" href="/admin/invitados">Limpiar</a>
-            </form>
-            <form class="import-form" action="/upload" method="post" enctype="multipart/form-data">
-                <label for="excel" style="font-weight: 600; font-size: 13px;">Importar listado</label>
-                <input type="file" id="excel" name="excel" accept=".xlsx,.xls,.csv">
-                <button type="submit" class="btn btn-import">Importar</button>
-            </form>
+        <nav class="admin-nav">
+            <a href="#carga" class="is-active">Carga</a>
+            <a href="#descargas">Descargas</a>
+            <a href="#invitados">Invitados</a>
+            <a href="#herramientas">Herramientas</a>
+        </nav>
+        <div class="sidebar-actions">
             <a class="btn btn-new" href="/admin/invitado/nuevo">Nuevo invitado</a>
-            <a class="btn btn-backup" href="/admin/backup">Descargar respaldo</a>
             <form action="/admin-logout" method="get">
                 <button class="btn-logout">Cerrar Sesión</button>
             </form>
         </div>
-    </div>
+    </aside>
+    <main class="admin-content">
+        <div class="container">
+            <section id="carga" class="admin-section">
+                <div class="header-controls">
+                    <h2>Carga y búsqueda</h2>
+                    <div class="header-actions">
+                        <form class="search-form" action="/admin/invitados" method="get">
+                            <label for="buscar" style="font-weight: 600; font-size: 13px;">Buscar</label>
+                            <input id="buscar" type="text" name="q" placeholder="Nombre o apellido" value="<%= termino || '' %>">
+                            <button type="submit" class="btn btn-search">Buscar</button>
+                            <a class="btn btn-secondary" href="/admin/invitados">Limpiar</a>
+                        </form>
+                        <form class="import-form" action="/upload" method="post" enctype="multipart/form-data">
+                            <label for="excel" style="font-weight: 600; font-size: 13px;">Importar listado</label>
+                            <input type="file" id="excel" name="excel" accept=".xlsx,.xls,.csv">
+                            <button type="submit" class="btn btn-import">Importar</button>
+                        </form>
+                    </div>
+                </div>
 
-    <% if (mensajeImportacion) { %>
-        <div class="alert alert-<%= mensajeImportacion.tipo %>"><%= mensajeImportacion.texto %></div>
-    <% } %>
+                <% if (mensajeImportacion) { %>
+                    <div class="alert alert-<%= mensajeImportacion.tipo %>"><%= mensajeImportacion.texto %></div>
+                <% } %>
 
-    <% if (mensajeExito) { %>
-        <div class="alert alert-exito"><%= mensajeExito %></div>
-    <% } %>
+                <% if (mensajeExito) { %>
+                    <div class="alert alert-exito"><%= mensajeExito %></div>
+                <% } %>
 
-    <% if (termino && invitados.length === 0) { %>
-        <div class="alert alert-info">No se encontraron invitados que coincidan con "<%= termino %>".</div>
-    <% } %>
+                <% if (termino && invitados.length === 0) { %>
+                    <div class="alert alert-info">No se encontraron invitados que coincidan con "<%= termino %>".</div>
+                <% } %>
+            </section>
 
-    <div class="stats">
-        <div class="stat-card">
-            <h2>Invitaciones (Grupos)</h2>
-            <p style="color: #17a2b8;"><%= invitados.length %></p>
+            <section id="descargas" class="admin-section">
+                <h2>Descargas</h2>
+                <p>Obtén un respaldo actualizado de tus invitados para almacenarlo o consultarlo sin conexión.</p>
+                <a class="btn btn-backup" href="/admin/backup">Descargar respaldo</a>
+            </section>
+
+            <section id="invitados" class="admin-section">
+                <h2>Resumen de invitados</h2>
+                <div class="stats">
+                    <div class="stat-card">
+                        <h3>Invitaciones (Grupos)</h3>
+                        <p style="color: #17a2b8;"><%= invitados.length %></p>
+                    </div>
+                    <div class="stat-card">
+                        <h3>Invitados (Personas)</h3>
+                        <p style="color: #007bff;"><%= totalInvitados %></p>
+                    </div>
+                    <div class="stat-card">
+                        <h3>Asistentes (Personas)</h3>
+                        <p style="color: #28a745;"><%= confirmados %></p>
+                    </div>
+                    <div class="stat-card">
+                        <h3>Pendientes (Invitaciones)</h3>
+                        <p style="color: #6c757d;"><%= pendientes %></p>
+                    </div>
+                    <div class="stat-card">
+                        <h3>Rechazados (Invitaciones)</h3>
+                        <p style="color: #dc3545;"><%= rechazados %></p>
+                    </div>
+                </div>
+                <div class="table-container">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Nombre</th>
+                            <th>Apellido</th>
+                            <th>Invitados (Grupo)</th>
+                            <th>Asistirán</th>
+                            <th>Estado</th>
+                            <th>Link</th>
+                            <th>Acciones</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <% invitados.forEach(invitado => { %>
+                            <tr>
+                                <td><%= invitado.nombre %></td>
+                                <td><%= invitado.apellido || '-' %></td>
+                                <td><%= invitado.cantidad %></td>
+                                <td><%= invitado.confirmados %></td>
+                                <td>
+                                    <span class="status status-<%= invitado.estado.toLowerCase() %>">
+                                        <%= invitado.estado %>
+                                    </span>
+                                </td>
+                                <td class="link-cell">
+                                    <a target="_blank" href="<%= baseUrl %>/confirmar/<%= invitado.id %>"><%= baseUrl %>/confirmar/<%= invitado.id %></a>
+                                </td>
+                                <td>
+                                    <div class="action-buttons">
+                                        <a href="/admin/invitado/editar/<%= invitado.id %>" class="btn btn-edit">Editar</a>
+                                        <form action="/admin/invitado/eliminar/<%= invitado.id %>" method="POST" onsubmit="return confirm('¿Seguro que quers eliminar a <%= invitado.nombre %> <%= invitado.apellido || '' %>? Esta acción no se puede deshacer.');">
+                                            <button type="submit" class="btn btn-delete">Eliminar</button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        <% }); %>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section id="herramientas" class="admin-section">
+                <h2>Herramientas adicionales</h2>
+                <p>Administra tus listas con estas acciones rápidas.</p>
+                <ul>
+                    <li><a href="/admin/invitado/nuevo">Agregar una nueva invitación</a></li>
+                    <li><a href="/admin/invitados">Volver al listado completo</a></li>
+                </ul>
+            </section>
         </div>
-        <div class="stat-card">
-            <h2>Invitados (Personas)</h2>
-            <p style="color: #007bff;"><%= totalInvitados %></p>
-        </div>
-        <div class="stat-card">
-            <h2>Asistentes (Personas)</h2>
-            <p style="color: #28a745;"><%= confirmados %></p>
-        </div>
-        <div class="stat-card">
-            <h2>Pendientes (Invitaciones)</h2>
-            <p style="color: #6c757d;"><%= pendientes %></p>
-        </div>
-        <div class="stat-card">
-            <h2>Rechazados (Invitaciones)</h2>
-            <p style="color: #dc3545;"><%= rechazados %></p>
-        </div>
-    </div>
-    <div class="table-container">
-        <table>
-            <thead>
-            <tr>
-                <th>Nombre</th>
-                <th>Apellido</th>
-                <th>Invitados (Grupo)</th>
-                <th>Asistirán</th>
-                <th>Estado</th>
-                <th>Link</th>
-                <th>Acciones</th>
-            </tr>
-            </thead>
-            <tbody>
-            <% invitados.forEach(invitado => { %>
-                <tr>
-                    <td><%= invitado.nombre %></td>
-                    <td><%= invitado.apellido || '-' %></td>
-                    <td><%= invitado.cantidad %></td>
-                    <td><%= invitado.confirmados %></td>
-                    <td>
-                        <span class="status status-<%= invitado.estado.toLowerCase() %>">
-                            <%= invitado.estado %>
-                        </span>
-                    </td>
-                    <td class="link-cell">
-                        <a target="_blank" href="<%= baseUrl %>/confirmar/<%= invitado.id %>"><%= baseUrl %>/confirmar/<%= invitado.id %></a>
-                    </td>
-                    <td>
-                        <div class="action-buttons">
-                            <a href="/admin/invitado/editar/<%= invitado.id %>" class="btn btn-edit">Editar</a>
-                            <form action="/admin/invitado/eliminar/<%= invitado.id %>" method="POST" onsubmit="return confirm('¿Seguro que querés eliminar a <%= invitado.nombre %> <%= invitado.apellido || '' %>? Esta acción no se puede deshacer.');">
-                                <button type="submit" class="btn btn-delete">Eliminar</button>
-                            </form>
-                        </div>
-                    </td>
-                </tr>
-            <% }); %>
-            </tbody>
-        </table>
-    </div>
+    </main>
 </div>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const navLinks = Array.from(document.querySelectorAll('.admin-nav a'));
+        const sections = Array.from(document.querySelectorAll('.admin-section'));
+
+        const activate = (hash) => {
+            const currentHash = hash || '#carga';
+            navLinks.forEach(link => {
+                link.classList.toggle('is-active', link.getAttribute('href') === currentHash);
+            });
+            sections.forEach(section => {
+                section.classList.toggle('is-active', `#${section.id}` === currentHash);
+            });
+        };
+
+        navLinks.forEach(link => {
+            link.addEventListener('click', (event) => {
+                activate(event.currentTarget.getAttribute('href'));
+            });
+        });
+
+        activate(window.location.hash);
+        window.addEventListener('hashchange', () => activate(window.location.hash));
+    });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reorganize the admin invitados view into a two-column flex shell with sidebar navigation
- split existing content into targeted sections for carga, descargas, invitados, and herramientas with responsive styling
- add a small script to highlight the active section when navigating from the sidebar

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68dd399a3d58832ba22ce40e602636fb