### PR TITLE
Allow admin sidebar to scroll when viewport is shorter

### DIFF
--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -29,7 +29,9 @@
             gap: 24px;
             position: sticky;
             top: 0;
-            height: 100vh;
+            max-height: 100vh;
+            overflow-y: auto;
+            box-sizing: border-box;
             box-shadow: 4px 0 24px rgba(13, 27, 42, 0.15);
         }
         .admin-sidebar h1 {


### PR DESCRIPTION
## Summary
- adjust the admin sidebar styling to use a max-height and overflow so it can scroll when its content exceeds the viewport height
- ensure padding is included in the sidebar height calculation via `box-sizing: border-box`

## Testing
- npm start


------
https://chatgpt.com/codex/tasks/task_e_68dd49777bd8832b944d92f79a3256ef