### PR TITLE
Add toast feedback after RSVP submission

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,6 +231,7 @@ app.post("/upload", upload.single("excel"), async (req, res) => {
 // RUTA DE CONFIRMACIÓN MODIFICADA (Esta es la sección a reemplazar)
 app.get("/confirmar/:id", async (req, res) => {
     const id = req.params.id;
+    const mostrarToast = req.query.exito === "1";
 
     try {
         const invitado = await db.one("SELECT * FROM invitados WHERE id = ?", [id]);
@@ -266,7 +267,8 @@ app.get("/confirmar/:id", async (req, res) => {
             invitado,
             bloquearFormulario,
             alerta,
-            mostrarResumen
+            mostrarResumen,
+            mostrarToast
         });
     } catch (error) {
         console.error("Error al obtener invitado:", error);
@@ -314,7 +316,8 @@ app.post("/confirmar/:id", async (req, res) => {
                     tipo: "info",
                     mensaje: mensajeInfo
                 },
-                mostrarResumen: false
+                mostrarResumen: false,
+                mostrarToast: false
             });
         }
 

--- a/views/invitacion.ejs
+++ b/views/invitacion.ejs
@@ -50,6 +50,55 @@
         }
 
 
+        .respuesta-toast {
+            position: fixed;
+            top: 18px;
+            left: 50%;
+            transform: translate(-50%, -16px);
+            background: rgba(47, 61, 92, 0.95);
+            color: #fff;
+            padding: 12px 28px;
+            border-radius: 999px;
+            font-weight: 600;
+            letter-spacing: 0.3px;
+            z-index: 12000;
+            box-shadow: 0 10px 28px rgba(0, 0, 0, 0.25);
+            opacity: 0;
+            animation: toastFadeIn 0.35s ease-out forwards, toastFadeOut 0.35s ease-in forwards;
+            animation-delay: 0s, 4s;
+        }
+
+        .respuesta-toast small {
+            display: block;
+            font-size: 0.75rem;
+            font-weight: 400;
+            margin-top: 4px;
+            opacity: 0.85;
+        }
+
+        @keyframes toastFadeIn {
+            0% {
+                opacity: 0;
+                transform: translate(-50%, -16px);
+            }
+            100% {
+                opacity: 1;
+                transform: translate(-50%, 0);
+            }
+        }
+
+        @keyframes toastFadeOut {
+            0% {
+                opacity: 1;
+                transform: translate(-50%, 0);
+            }
+            100% {
+                opacity: 0;
+                transform: translate(-50%, -16px);
+            }
+        }
+
+
         /* ================================== */
         /* == ESTILOS ORIGINALES AJUSTADOS == */
         /* ================================== */
@@ -744,6 +793,13 @@
 <body>
 
 <div class="mobile-container">
+
+    <% if (mostrarToast && alerta) { %>
+        <div class="respuesta-toast" role="status" aria-live="polite">
+            ¡Gracias por tu respuesta!
+            <small><%= alerta.mensaje %></small>
+        </div>
+    <% } %>
 
 
 


### PR DESCRIPTION
## Summary
- show a toast message thanking guests after they confirm or rechazar la invitación
- pass a flag from the confirmation route so the toast only appears when the respuesta fue guardada

## Testing
- npm start *(fails: database connection ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68dd8c0d8ed0832b828b3e5ef8aeb78e