### PR TITLE
Add loading spinner and status indicator to admin guest search form

### DIFF
--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -155,6 +155,14 @@
             from { box-shadow: 0 0 0 rgba(13, 110, 253, 0); }
             to { box-shadow: 0 0 0 rgba(13, 110, 253, 0); }
         }
+        @keyframes searchFormSpinner {
+            from {
+                transform: translateY(-50%) rotate(0deg);
+            }
+            to {
+                transform: translateY(-50%) rotate(360deg);
+            }
+        }
         .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 20px; margin-bottom: 30px; }
         .stat-card { background: #f1f3f5; padding: 24px; border-radius: 12px; text-align: center; border: 1px solid rgba(13, 27, 42, 0.08); box-shadow: 0 10px 30px rgba(13, 27, 42, 0.05); }
         .stat-card h2,
@@ -189,6 +197,7 @@
         }
         .table-container { overflow-x: auto; }
         .search-form {
+            position: relative;
             display: flex;
             flex-direction: column;
             align-items: stretch;
@@ -196,6 +205,30 @@
             background: none;
             padding: 0;
             border: none;
+        }
+        .search-form::after {
+            content: "";
+            position: absolute;
+            top: 18px;
+            right: 18px;
+            width: 18px;
+            height: 18px;
+            border-radius: 50%;
+            border: 2px solid rgba(13, 27, 42, 0.2);
+            border-top-color: #0d6efd;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.2s ease;
+            transform: translateY(-50%);
+            transform-origin: center;
+            animation: searchFormSpinner 0.8s linear infinite;
+        }
+        .search-form.is-loading {
+            opacity: 0.6;
+            pointer-events: none;
+        }
+        .search-form.is-loading::after {
+            opacity: 1;
         }
         .search-form label {
             font-weight: 600;
@@ -217,6 +250,16 @@
             border-color: #0d6efd;
             outline: none;
             box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.2);
+        }
+        .search-status {
+            display: none;
+            align-items: center;
+            gap: 8px;
+            font-size: 0.9rem;
+            color: #0d1b2a;
+        }
+        .search-form.is-loading .search-status {
+            display: inline-flex;
         }
         .search-actions {
             display: flex;
@@ -326,43 +369,6 @@
             clip: rect(0, 0, 0, 0);
             white-space: nowrap;
             border: 0;
-        }
-        .search-form {
-            display: flex;
-            flex-direction: column;
-            align-items: stretch;
-            gap: 12px;
-            background: none;
-            padding: 0;
-            border: none;
-        }
-        .search-form.is-loading {
-            opacity: 0.6;
-            pointer-events: none;
-        }
-        .search-form label {
-            font-weight: 600;
-            font-size: 13px;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            color: #495057;
-        }
-        .search-form input[type="text"] {
-            padding: 10px 12px;
-            border: 1px solid #ced4da;
-            border-radius: 8px;
-            font-size: 15px;
-            transition: border-color 0.2s ease, box-shadow 0.2s ease;
-        }
-        .search-form input[type="text"]:focus {
-            border-color: #0d6efd;
-            outline: none;
-            box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.2);
-        }
-        .search-actions {
-            display: flex;
-            gap: 12px;
-            flex-wrap: wrap;
         }
         .search-actions button,
         .search-actions a {
@@ -525,6 +531,9 @@
                             <div class="search-actions">
                                 <button type="submit" class="btn btn-search">Buscar</button>
                                 <a class="btn btn-secondary" href="/admin/invitados" data-action="clear">Limpiar</a>
+                            </div>
+                            <div class="search-status" role="status" aria-live="polite" aria-hidden="true" data-search-status>
+                                Buscando…
                             </div>
                         </form>
                     </article>
@@ -728,6 +737,7 @@
         const clearButton = searchForm ? searchForm.querySelector('[data-action="clear"]') : null;
         const inputBuscar = searchForm ? searchForm.querySelector('input[name="q"]') : null;
         const selectEstado = searchForm ? searchForm.querySelector('select[name="estado"]') : null;
+        const statusIndicator = searchForm ? searchForm.querySelector('[data-search-status]') : null;
         const statElements = {
             grupos: document.querySelector('[data-stat="grupos"]'),
             personas: document.querySelector('[data-stat="personas"]'),
@@ -738,6 +748,10 @@
 
         if (!searchForm || !tableBody) {
             return;
+        }
+
+        if (statusIndicator) {
+            statusIndicator.textContent = '';
         }
 
         const initialState = <%- JSON.stringify({
@@ -764,13 +778,18 @@
         };
 
         function setLoading(isLoading) {
-            searchForm.classList.toggle('is-loading', Boolean(isLoading));
+            const loading = Boolean(isLoading);
+            searchForm.classList.toggle('is-loading', loading);
             if (submitButton) {
-                submitButton.disabled = Boolean(isLoading);
-                submitButton.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+                submitButton.disabled = loading;
+                submitButton.setAttribute('aria-busy', loading ? 'true' : 'false');
             }
             if (clearButton) {
-                clearButton.setAttribute('aria-disabled', isLoading ? 'true' : 'false');
+                clearButton.setAttribute('aria-disabled', loading ? 'true' : 'false');
+            }
+            if (statusIndicator) {
+                statusIndicator.setAttribute('aria-hidden', loading ? 'false' : 'true');
+                statusIndicator.textContent = loading ? 'Buscando…' : '';
             }
         }
 


### PR DESCRIPTION
## Summary
- add a CSS-based loading spinner to the admin guest search form and position it relative to the form
- include an accessible status container that surfaces the “Buscando…” message only while loading
- update the client script to toggle the status visibility and aria attributes alongside the loading state

## Testing
- npm test *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68de68751778832baf3315fc3e5920a4