### PR TITLE
Add admin backup restoration endpoint and UI

### DIFF
--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -628,6 +628,15 @@
                                 Confirmaciones
                             </a>
                         </div>
+                        <form class="restore-form" action="/admin/restaurar-backup" method="post" enctype="multipart/form-data">
+                            <label for="backup" class="visually-hidden">Seleccionar archivo de respaldo</label>
+                            <input type="file" id="backup" name="backup" accept="application/json,.json" required>
+                            <button type="submit" class="btn btn-secondary btn-icon">
+                                <span aria-hidden="true">↩️</span>
+                                Restaurar respaldo
+                            </button>
+                        </form>
+                        <small style="color: #6c757d; display: block; margin-top: 0.5rem;">Al restaurar se reemplazarán los registros actuales por los del archivo seleccionado.</small>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- add validation helpers and a protected `/admin/restaurar-backup` endpoint to restore invitados data from JSON backups
- extend admin list alerts to reflect restore outcomes and surface them in the UI
- add a restore form to the backups card so admins can upload and apply a JSON backup

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dea5deeb78832bb57ec5f0d1fa8072