### PR TITLE
Handle import conflicts during guest import

### DIFF
--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -916,7 +916,8 @@
                 pendientes,
                 rechazados
             },
-            alerts: typeof alerts !== 'undefined' ? alerts : []
+            alerts: typeof alerts !== 'undefined' ? alerts : [],
+            importSummary: typeof importSummary !== 'undefined' ? importSummary : null
         }) %>;
 
         const state = {
@@ -924,7 +925,8 @@
                 termino: initialState.termino || "",
                 estado: initialState.estadoSeleccionado || "todos"
             },
-            baseUrl: initialState.baseUrl || window.location.origin
+            baseUrl: initialState.baseUrl || window.location.origin,
+            importSummary: initialState.importSummary || null
         };
 
         function getEmptyResultsMessage() {


### PR DESCRIPTION
## Summary
- detect existing guests during spreadsheet imports, updating their data when fields change and logging conflicts
- report import outcomes back to the admin list via session-backed alerts, including conflict summaries
- expose the latest import summary to the client bootstrap data for future UI needs

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68ded6dee120832b8daf51dfc316924e