### PR TITLE
Expand analytics dashboard and centralize AI configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,26 @@ Tras ejecutar el comando, el servidor (`app.js`) entregará automáticamente las
 ## Respaldos de la base de datos
 
 El panel de administración ofrece una ruta de respaldo que exporta los registros de `invitados` a un archivo JSON ordenado por nombre. Este archivo se guarda temporalmente en la carpeta `backups/` y luego se ofrece para su descarga. Podés versionar o almacenar el JSON resultante en tu proveedor de confianza para contar con una copia remota de la información.
+
+## Configuración de la IA
+
+La integración con el asistente de inteligencia artificial se configura en `config/ai.js`. Definí las siguientes variables de entorno antes de iniciar la aplicación:
+
+- `AI_API_KEY` (**obligatorio**): clave privada del proveedor elegido.
+- `AI_MODEL` (**obligatorio**): identificador exacto del modelo a utilizar.
+- `AI_PROVIDER` (opcional): nombre del proveedor, por defecto `openai`.
+- `AI_ENDPOINT` (opcional): URL del endpoint si necesitás uno personalizado.
+- `AI_LOCALE` (opcional): locale preferido para las respuestas, por defecto `es-AR`.
+
+El panel de administración muestra el estado de la configuración. Cuando falten variables obligatorias, se indicará qué valores están pendientes para facilitar el ajuste.
+
+## Panel analítico ampliado
+
+El panel de invitados incluye métricas avanzadas para tomar decisiones logísticas y presupuestarias. Además de los totales por estado, se calculan tasas de confirmación y respuesta, cupos disponibles y promedios por invitación. Los datos se presentan en tarjetas descriptivas y gráficos con leyendas explícitas (barras para grupos y gráfico de torta/donut para personas).
+
+Variables opcionales para personalizar los cálculos:
+
+- `EVENT_COSTO_POR_INVITADO_ARS`: define un costo unitario en pesos argentinos para estimar la inversión confirmada y potencial.
+- `EVENT_CAPACIDAD_MAXIMA`: establece el cupo total planificado para calcular ocupación y lugares disponibles.
+
+Si configurás estos valores, el panel añadirá métricas de presupuesto y capacidad con formato `$ (ARS)` para evitar ambigüedades en la moneda.

--- a/app.js
+++ b/app.js
@@ -7,11 +7,14 @@ const XLSX = require("xlsx");
 const session = require("express-session");
 const compression = require("compression");
 const db = require("./db/client");
+const aiConfig = require("./config/ai");
 
 const app = express();
 const upload = multer({ dest: "uploads/" });
 const ESTADOS_VALIDOS = new Set(["pendiente", "confirmado", "rechazado"]);
 const isProduction = process.env.NODE_ENV === "production";
+const eventCostPerPersonARS = Number.parseFloat(process.env.EVENT_COSTO_POR_INVITADO_ARS || "0") || 0;
+const eventCapacityPlanned = Number.parseInt(process.env.EVENT_CAPACIDAD_MAXIMA || "0", 10) || 0;
 
 const CLAVE_CORRECTA = "Victoria2025**";
 
@@ -43,6 +46,13 @@ const assetCacheOptions = {
 
 // app.use("/admin", checkAdmin, express.static("public"));
 
+if (!aiConfig.isConfigured) {
+    const missingVars = aiConfig.missing.length ? aiConfig.missing.join(", ") : "AI_API_KEY, AI_MODEL";
+    console.warn(`[IA] Configuración incompleta. Definí las variables: ${missingVars}.`);
+}
+
+app.locals.ai = aiConfig.getPublicConfig();
+
 function checkAdmin(req, res, next) {
     if (req.session && req.session.adminAutenticado) return next();
     // Permite el acceso a la página de login sin estar autenticado
@@ -53,6 +63,104 @@ function checkAdmin(req, res, next) {
 function wantsJson(req) {
     const accept = req.headers.accept || "";
     return req.xhr || accept.includes("application/json");
+}
+
+function toNumber(value) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function roundTo(value, digits) {
+    if (!Number.isFinite(value)) return 0;
+    const factor = 10 ** digits;
+    return Math.round(value * factor) / factor;
+}
+
+function buildAnalytics(invitados) {
+    const totalGrupos = Array.isArray(invitados) ? invitados.length : 0;
+    let totalPersonas = 0;
+    let totalConfirmados = 0;
+    let gruposPendientes = 0;
+    let gruposConfirmados = 0;
+    let gruposRechazados = 0;
+    let personasPendientes = 0;
+    let personasRechazadas = 0;
+    let gruposConAsistenciaParcial = 0;
+
+    for (const invitado of invitados || []) {
+        const cantidad = toNumber(invitado?.cantidad);
+        const confirmados = toNumber(invitado?.confirmados);
+        const estado = (invitado?.estado || "").toLowerCase();
+
+        totalPersonas += cantidad;
+        totalConfirmados += confirmados;
+
+        if (estado === "pendiente") {
+            gruposPendientes += 1;
+            personasPendientes += Math.max(cantidad - confirmados, 0);
+        } else if (estado === "confirmado") {
+            gruposConfirmados += 1;
+            if (confirmados < cantidad) {
+                gruposConAsistenciaParcial += 1;
+                personasPendientes += Math.max(cantidad - confirmados, 0);
+            }
+        } else if (estado === "rechazado") {
+            gruposRechazados += 1;
+            personasRechazadas += cantidad;
+        } else {
+            personasPendientes += Math.max(cantidad - confirmados, 0);
+        }
+    }
+
+    const gruposRespondieron = gruposConfirmados + gruposRechazados;
+    const capacidadDisponible = Math.max(totalPersonas - totalConfirmados, 0);
+    const porcentajeConfirmacion = totalPersonas > 0 ? roundTo((totalConfirmados / totalPersonas) * 100, 1) : 0;
+    const porcentajeRespuesta = totalGrupos > 0 ? roundTo((gruposRespondieron / totalGrupos) * 100, 1) : 0;
+    const promedioPersonasGrupo = totalGrupos > 0 ? roundTo(totalPersonas / totalGrupos, 1) : 0;
+    const promedioAsistentesPorGrupoConfirmado = gruposConfirmados > 0 ? roundTo(totalConfirmados / gruposConfirmados, 1) : 0;
+
+    const capacidadRestanteEvento = eventCapacityPlanned > 0
+        ? Math.max(eventCapacityPlanned - totalConfirmados, 0)
+        : 0;
+    const porcentajeOcupacionPlaneada = eventCapacityPlanned > 0
+        ? roundTo((totalConfirmados / eventCapacityPlanned) * 100, 1)
+        : 0;
+
+    const costoConfirmadosARS = eventCostPerPersonARS > 0 ? roundTo(totalConfirmados * eventCostPerPersonARS, 2) : 0;
+    const costoPendienteARS = eventCostPerPersonARS > 0 ? roundTo(personasPendientes * eventCostPerPersonARS, 2) : 0;
+
+    return {
+        totalGrupos,
+        totalPersonas,
+        confirmados: totalConfirmados,
+        pendientes: gruposPendientes,
+        rechazados: gruposRechazados,
+        personasPendientes,
+        personasRechazadas,
+        capacidadDisponible,
+        porcentajeConfirmacion,
+        porcentajeRespuesta,
+        gruposRespondieron,
+        gruposConAsistenciaParcial,
+        promedioPersonasGrupo,
+        promedioAsistentesPorGrupoConfirmado,
+        costoPorPersonaARS: eventCostPerPersonARS,
+        costoConfirmadosARS,
+        costoPendienteARS,
+        capacidadPlaneada: eventCapacityPlanned,
+        capacidadRestanteEvento,
+        porcentajeOcupacionPlaneada,
+        distribucionGrupos: {
+            confirmado: gruposConfirmados,
+            pendiente: gruposPendientes,
+            rechazado: gruposRechazados
+        },
+        distribucionPersonas: {
+            confirmadas: totalConfirmados,
+            pendientes: personasPendientes,
+            rechazadas: personasRechazadas
+        }
+    };
 }
 
 function normalizarNumero(valor) {
@@ -659,15 +767,12 @@ app.get("/admin/invitados", checkAdmin, async (req, res) => {
         const whereClause = condiciones.length ? `WHERE ${condiciones.join(" AND ")}` : "";
         const sql = `SELECT * FROM invitados ${whereClause} ORDER BY nombre`;
         const invitados = await db.many(sql, parametros);
+        const analytics = buildAnalytics(invitados);
 
-        let totalInvitados = 0;
-        let confirmados = 0;
-        invitados.forEach(r => {
-            totalInvitados += Number(r.cantidad) || 0;
-            confirmados += Number(r.confirmados) || 0;
-        });
-        const pendientes = invitados.filter(r => r.estado === "pendiente").length;
-        const rechazados = invitados.filter(r => r.estado === "rechazado").length;
+        const totalInvitados = analytics.totalPersonas;
+        const confirmados = analytics.confirmados;
+        const pendientes = analytics.distribucionGrupos.pendiente;
+        const rechazados = analytics.distribucionGrupos.rechazado;
         const baseUrl = req.protocol + "://" + req.get("host");
 
         const mensajeExito = req.query.exito === "1" ? "Invitado eliminado correctamente." : null;
@@ -788,13 +893,8 @@ app.get("/admin/invitados", checkAdmin, async (req, res) => {
             return res.json({
                 ok: true,
                 invitados,
-                stats: {
-                    totalGrupos: invitados.length,
-                    totalPersonas: totalInvitados,
-                    confirmados,
-                    pendientes,
-                    rechazados
-                },
+                stats: analytics,
+                ai: aiConfig.getPublicConfig(),
                 baseUrl,
                 termino: termino || "",
                 estadoSeleccionado,
@@ -817,7 +917,9 @@ app.get("/admin/invitados", checkAdmin, async (req, res) => {
             termino,
             estadoSeleccionado,
             alerts,
-            importSummary: importSummaryData
+            importSummary: importSummaryData,
+            stats: analytics,
+            ai: aiConfig.getPublicConfig()
         });
     } catch (error) {
         console.error("Error al obtener invitados:", error);

--- a/config/ai.js
+++ b/config/ai.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const provider = (process.env.AI_PROVIDER || '').trim() || 'openai';
+const apiKey = (process.env.AI_API_KEY || '').trim();
+const model = (process.env.AI_MODEL || '').trim();
+const endpoint = (process.env.AI_ENDPOINT || '').trim();
+const defaultLocale = (process.env.AI_LOCALE || '').trim() || 'es-AR';
+
+const requiredFields = [
+    { key: 'apiKey', env: 'AI_API_KEY' },
+    { key: 'model', env: 'AI_MODEL' }
+];
+
+const missing = requiredFields
+    .filter((field) => {
+        if (field.key === 'apiKey') return !apiKey;
+        if (field.key === 'model') return !model;
+        return false;
+    })
+    .map((field) => field.env);
+
+const isConfigured = missing.length === 0;
+
+function getPublicConfig() {
+    return {
+        provider,
+        model,
+        endpoint,
+        defaultLocale,
+        isConfigured,
+        missing
+    };
+}
+
+module.exports = {
+    provider,
+    apiKey,
+    model,
+    endpoint,
+    defaultLocale,
+    isConfigured,
+    missing,
+    getPublicConfig
+};

--- a/views/admin_invitados.ejs
+++ b/views/admin_invitados.ejs
@@ -257,11 +257,176 @@
                 transform: translateY(-50%) rotate(360deg);
             }
         }
-        .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 20px; margin-bottom: 30px; }
-        .stat-card { background: #f1f3f5; padding: 24px; border-radius: 12px; text-align: center; border: 1px solid rgba(13, 27, 42, 0.08); box-shadow: 0 10px 30px rgba(13, 27, 42, 0.05); }
-        .stat-card h2,
-        .stat-card h3 { margin: 0 0 10px 0; font-size: 0.95em; color: #495057; text-transform: uppercase; letter-spacing: 0.08em; }
-        .stat-card p { margin: 0; font-size: 2.3em; font-weight: 700; }
+        .stats {
+            display: grid;
+            gap: 20px;
+        }
+        .metrics-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 20px;
+        }
+        .stat-card {
+            background: #f1f3f5;
+            padding: 24px;
+            border-radius: 12px;
+            border: 1px solid rgba(13, 27, 42, 0.08);
+            box-shadow: 0 10px 30px rgba(13, 27, 42, 0.05);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            text-align: left;
+        }
+        .stat-card h3 {
+            margin: 0;
+            font-size: 0.85rem;
+            color: #495057;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .stat-card__value {
+            margin: 0;
+            font-size: 2.3rem;
+            font-weight: 700;
+            color: #0d1b2a;
+        }
+        .stat-card__meta {
+            margin: 0;
+            font-size: 0.95rem;
+            color: #495057;
+            line-height: 1.4;
+        }
+        .analytics-panels {
+            display: flex;
+            flex-direction: column;
+            gap: 28px;
+        }
+        .analytics-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+            background: #fff;
+            border: 1px solid rgba(13, 27, 42, 0.06);
+            border-radius: 16px;
+            padding: 24px;
+            box-shadow: inset 0 0 0 1px rgba(13, 27, 42, 0.03);
+        }
+        .analytics-panel header h3 {
+            margin: 0;
+            color: #0d1b2a;
+            font-size: 1.2rem;
+        }
+        .analytics-panel header p {
+            margin: 4px 0 0;
+            color: #495057;
+            max-width: 720px;
+        }
+        .analytics-charts {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 24px;
+        }
+        .chart-card {
+            background: rgba(239, 244, 255, 0.6);
+            border: 1px solid rgba(13, 27, 42, 0.08);
+            border-radius: 16px;
+            padding: 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        .chart-card figure,
+        .chart-card canvas {
+            width: 100%;
+        }
+        .chart-card canvas {
+            min-height: 260px;
+        }
+        .chart-card figcaption {
+            margin: 0;
+            font-size: 0.9rem;
+            color: #495057;
+        }
+        .insight-card {
+            background: rgba(248, 249, 250, 0.8);
+            border: 1px solid rgba(13, 27, 42, 0.08);
+            border-radius: 16px;
+            padding: 20px;
+        }
+        .insight-card h4 {
+            margin: 0 0 12px;
+            color: #0d1b2a;
+        }
+        .insight-card ul {
+            margin: 0;
+            padding-left: 20px;
+            color: #495057;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+        .insight-card li strong {
+            color: #0d1b2a;
+        }
+        .ai-status {
+            background: rgba(13, 27, 42, 0.04);
+            border: 1px solid rgba(13, 27, 42, 0.12);
+            border-radius: 12px;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .ai-status[data-ai-config="missing"] {
+            border-color: rgba(220, 53, 69, 0.45);
+            background: rgba(220, 53, 69, 0.08);
+        }
+        .ai-status__headline {
+            margin: 0;
+            font-size: 0.95rem;
+            color: #0d1b2a;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+        }
+        .ai-status__headline span {
+            font-weight: 600;
+        }
+        .ai-status__warning {
+            margin: 0;
+            color: #dc3545;
+            font-size: 0.9rem;
+        }
+        .ai-status__details {
+            margin: 0;
+            display: grid;
+            gap: 12px;
+        }
+        .ai-status__details div {
+            display: grid;
+            gap: 4px;
+        }
+        .ai-status__details dt {
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: #495057;
+        }
+        .ai-status__details dd {
+            margin: 0;
+            font-weight: 600;
+            color: #0d1b2a;
+        }
+        .ai-status__hint {
+            margin: 0;
+            font-size: 0.9rem;
+            color: #495057;
+        }
+        .ai-status code {
+            background: rgba(13, 27, 42, 0.08);
+            padding: 2px 6px;
+            border-radius: 4px;
+        }
         table { width: 100%; border-collapse: collapse; margin-top: 20px; font-size: 14px; }
         th, td { padding: 12px 15px; border: 1px solid #ddd; text-align: left; }
         th { background-color: #007bff; color: white; }
@@ -599,6 +764,7 @@
             }
         }
     </style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js" defer></script>
 </head>
 <body>
 <div class="admin-shell">
@@ -785,27 +951,206 @@
                         </div>
                     </header>
                     <div class="section-body">
-                        <div class="stats">
-                            <div class="stat-card">
-                                <h3>Invitaciones (Grupos)</h3>
-                                <p style="color: #17a2b8;" data-stat="grupos"><%= invitados.length %></p>
-                            </div>
-                            <div class="stat-card">
-                                <h3>Invitados (Personas)</h3>
-                                <p style="color: #007bff;" data-stat="personas"><%= totalInvitados %></p>
-                            </div>
-                            <div class="stat-card">
-                                <h3>Asistentes (Personas)</h3>
-                                <p style="color: #28a745;" data-stat="confirmados"><%= confirmados %></p>
-                            </div>
-                            <div class="stat-card">
-                                <h3>Pendientes (Invitaciones)</h3>
-                                <p style="color: #6c757d;" data-stat="pendientes"><%= pendientes %></p>
-                            </div>
-                            <div class="stat-card">
-                                <h3>Rechazados (Invitaciones)</h3>
-                                <p style="color: #dc3545;" data-stat="rechazados"><%= rechazados %></p>
-                            </div>
+                        <%
+                            const safeNumber = (value) => {
+                                const num = Number(value);
+                                return Number.isFinite(num) ? num : 0;
+                            };
+                            const totalGruposDefault = safeNumber(invitados.length);
+                            const totalPersonasDefault = safeNumber(totalInvitados);
+                            const confirmadosDefault = safeNumber(confirmados);
+                            const gruposPendientesDefault = safeNumber(pendientes);
+                            const gruposRechazadosDefault = safeNumber(rechazados);
+                            const gruposConfirmadosEstimado = Math.max(totalGruposDefault - gruposPendientesDefault - gruposRechazadosDefault, 0);
+                            const personasPendientesDefault = Math.max(totalPersonasDefault - confirmadosDefault, 0);
+                            const analytics = stats || {
+                                totalGrupos: totalGruposDefault,
+                                totalPersonas: totalPersonasDefault,
+                                confirmados: confirmadosDefault,
+                                pendientes: gruposPendientesDefault,
+                                rechazados: gruposRechazadosDefault,
+                                personasPendientes: personasPendientesDefault,
+                                personasRechazadas: 0,
+                                capacidadDisponible: personasPendientesDefault,
+                                porcentajeConfirmacion: totalPersonasDefault > 0 ? Number(((confirmadosDefault / totalPersonasDefault) * 100).toFixed(1)) : 0,
+                                porcentajeRespuesta: totalGruposDefault > 0 ? Number((((totalGruposDefault - gruposPendientesDefault) / totalGruposDefault) * 100).toFixed(1)) : 0,
+                                gruposRespondieron: Math.max(totalGruposDefault - gruposPendientesDefault, 0),
+                                gruposConAsistenciaParcial: 0,
+                                promedioPersonasGrupo: totalGruposDefault > 0 ? Number((totalPersonasDefault / totalGruposDefault).toFixed(1)) : 0,
+                                promedioAsistentesPorGrupoConfirmado: gruposConfirmadosEstimado > 0 ? Number((confirmadosDefault / gruposConfirmadosEstimado).toFixed(1)) : 0,
+                                costoPorPersonaARS: 0,
+                                costoConfirmadosARS: 0,
+                                costoPendienteARS: 0,
+                                capacidadPlaneada: 0,
+                                capacidadRestanteEvento: 0,
+                                porcentajeOcupacionPlaneada: 0,
+                                distribucionGrupos: {
+                                    confirmado: gruposConfirmadosEstimado,
+                                    pendiente: gruposPendientesDefault,
+                                    rechazado: gruposRechazadosDefault
+                                },
+                                distribucionPersonas: {
+                                    confirmadas: confirmadosDefault,
+                                    pendientes: personasPendientesDefault,
+                                    rechazadas: 0
+                                }
+                            };
+                            const formatInteger = (value) => Number(value || 0).toLocaleString('es-AR');
+                            const formatDecimal = (value) => Number(value || 0).toLocaleString('es-AR', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+                            const formatPercent = (value) => `${formatDecimal(value)}%`;
+                            const formatCurrency = (value) => `$ (ARS) ${Number(value || 0).toLocaleString('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+                        %>
+                        <div class="analytics-panels">
+                            <section class="analytics-panel">
+                                <header>
+                                    <h3>Indicadores generales</h3>
+                                    <p>Resumen de volumen y estado de las invitaciones para dimensionar la asistencia.</p>
+                                </header>
+                                <div class="metrics-grid">
+                                    <article class="stat-card">
+                                        <h3>Invitaciones (Grupos)</h3>
+                                        <p class="stat-card__value" data-stat="grupos"><%= formatInteger(analytics.totalGrupos) %></p>
+                                        <p class="stat-card__meta">Cantidad de invitaciones agrupadas por familia o mesa.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Invitados (Personas)</h3>
+                                        <p class="stat-card__value" data-stat="personas"><%= formatInteger(analytics.totalPersonas) %></p>
+                                        <p class="stat-card__meta">Personas incluidas en todas las invitaciones.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Personas confirmadas</h3>
+                                        <p class="stat-card__value" data-stat="confirmados"><%= formatInteger(analytics.confirmados) %></p>
+                                        <p class="stat-card__meta">Asistentes que ya confirmaron su presencia.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Invitaciones pendientes</h3>
+                                        <p class="stat-card__value" data-stat="pendientes"><%= formatInteger(analytics.pendientes) %></p>
+                                        <p class="stat-card__meta">Grupos que todavía no respondieron.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Invitaciones rechazadas</h3>
+                                        <p class="stat-card__value" data-stat="rechazados"><%= formatInteger(analytics.rechazados) %></p>
+                                        <p class="stat-card__meta">Grupos que comunicaron que no asistirán.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Personas que no asistirán</h3>
+                                        <p class="stat-card__value" data-stat="personas-rechazadas"><%= formatInteger(analytics.personasRechazadas) %></p>
+                                        <p class="stat-card__meta">Personas incluidas en invitaciones rechazadas.</p>
+                                    </article>
+                                </div>
+                            </section>
+                            <section class="analytics-panel">
+                                <header>
+                                    <h3>Indicadores estratégicos</h3>
+                                    <p>Datos para planificar logística, presupuesto y acciones de seguimiento.</p>
+                                </header>
+                                <div class="metrics-grid">
+                                    <article class="stat-card">
+                                        <h3>Tasa de confirmación</h3>
+                                        <p class="stat-card__value" data-stat="porcentaje-confirmacion"><%= formatPercent(analytics.porcentajeConfirmacion) %></p>
+                                        <p class="stat-card__meta">Porcentaje de personas confirmadas sobre el total invitado.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Tasa de respuesta</h3>
+                                        <p class="stat-card__value" data-stat="porcentaje-respuesta"><%= formatPercent(analytics.porcentajeRespuesta) %></p>
+                                        <p class="stat-card__meta">Invitaciones que ya respondieron (sí o no).</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Grupos con respuesta</h3>
+                                        <p class="stat-card__value" data-stat="grupos-respondieron"><%= formatInteger(analytics.gruposRespondieron) %></p>
+                                        <p class="stat-card__meta">Invitaciones que confirmaron o rechazaron.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Personas por confirmar</h3>
+                                        <p class="stat-card__value" data-stat="personas-pendientes"><%= formatInteger(analytics.personasPendientes) %></p>
+                                        <p class="stat-card__meta">Personas sin respuesta o con asistencia parcial.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Capacidad disponible</h3>
+                                        <p class="stat-card__value" data-stat="capacidad-disponible"><%= formatInteger(analytics.capacidadDisponible) %></p>
+                                        <p class="stat-card__meta">Cupos libres considerando confirmaciones y rechazos.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Asistencia parcial</h3>
+                                        <p class="stat-card__value" data-stat="grupos-parciales"><%= formatInteger(analytics.gruposConAsistenciaParcial) %></p>
+                                        <p class="stat-card__meta">Grupos que confirmaron menos personas de las invitadas.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Promedio por grupo</h3>
+                                        <p class="stat-card__value" data-stat="promedio-personas"><%= formatDecimal(analytics.promedioPersonasGrupo) %></p>
+                                        <p class="stat-card__meta">Personas promedio por invitación enviada.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Promedio confirmados</h3>
+                                        <p class="stat-card__value" data-stat="promedio-asistentes-grupo"><%= formatDecimal(analytics.promedioAsistentesPorGrupoConfirmado) %></p>
+                                        <p class="stat-card__meta">Asistentes promedio entre las invitaciones confirmadas.</p>
+                                    </article>
+                                    <% if (analytics.costoPorPersonaARS > 0) { %>
+                                    <article class="stat-card">
+                                        <h3>Costo por persona</h3>
+                                        <p class="stat-card__value" data-stat="costo-persona"><%= formatCurrency(analytics.costoPorPersonaARS) %></p>
+                                        <p class="stat-card__meta">Valor presupuestado por persona en pesos argentinos.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Inversión confirmada</h3>
+                                        <p class="stat-card__value" data-stat="costo-confirmados"><%= formatCurrency(analytics.costoConfirmadosARS) %></p>
+                                        <p class="stat-card__meta">Estimación total para quienes ya confirmaron.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Compromiso potencial</h3>
+                                        <p class="stat-card__value" data-stat="costo-pendiente"><%= formatCurrency(analytics.costoPendienteARS) %></p>
+                                        <p class="stat-card__meta">Monto adicional si confirman las personas pendientes.</p>
+                                    </article>
+                                    <% } %>
+                                    <% if (analytics.capacidadPlaneada > 0) { %>
+                                    <article class="stat-card">
+                                        <h3>Capacidad planificada</h3>
+                                        <p class="stat-card__value" data-stat="capacidad-planeada"><%= formatInteger(analytics.capacidadPlaneada) %></p>
+                                        <p class="stat-card__meta">Cupos totales definidos para el evento.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Cupos disponibles (plan)</h3>
+                                        <p class="stat-card__value" data-stat="capacidad-restante-evento"><%= formatInteger(analytics.capacidadRestanteEvento) %></p>
+                                        <p class="stat-card__meta">Disponibles según la capacidad planificada.</p>
+                                    </article>
+                                    <article class="stat-card">
+                                        <h3>Ocupación planificada</h3>
+                                        <p class="stat-card__value" data-stat="capacidad-ocupada-porcentaje"><%= formatPercent(analytics.porcentajeOcupacionPlaneada) %></p>
+                                        <p class="stat-card__meta">Nivel de ocupación frente al cupo máximo.</p>
+                                    </article>
+                                    <% } %>
+                                </div>
+                            </section>
+                            <section class="analytics-panel">
+                                <header>
+                                    <h3>Visualizaciones y alertas</h3>
+                                    <p>Gráficos y resumen textual para compartir con tu equipo.</p>
+                                </header>
+                                <div class="analytics-charts">
+                                    <figure class="chart-card">
+                                        <canvas id="chart-estado-grupos" aria-label="Distribución de invitaciones por estado (grupos)" role="img"></canvas>
+                                        <figcaption>Comparativa de grupos confirmados, pendientes y rechazados. Valores expresados en cantidad de invitaciones.</figcaption>
+                                    </figure>
+                                    <figure class="chart-card">
+                                        <canvas id="chart-estado-personas" aria-label="Distribución de personas según respuesta" role="img"></canvas>
+                                        <figcaption>Personas confirmadas, pendientes y que no asistirán. Valores expresados en cantidad de personas.</figcaption>
+                                    </figure>
+                                </div>
+                                <article class="insight-card">
+                                    <h4>Resumen ejecutivo</h4>
+                                    <ul>
+                                        <li><strong>Confirmaciones:</strong> <span data-stat="confirmados"><%= formatInteger(analytics.confirmados) %></span> personas sobre un total de <span data-stat="personas"><%= formatInteger(analytics.totalPersonas) %></span>.</li>
+                                        <li><strong>Por gestionar:</strong> <span data-stat="personas-pendientes"><%= formatInteger(analytics.personasPendientes) %></span> personas distribuidas en <span data-stat="pendientes"><%= formatInteger(analytics.pendientes) %></span> invitaciones.</li>
+                                        <li><strong>No asistirán:</strong> <span data-stat="personas-rechazadas"><%= formatInteger(analytics.personasRechazadas) %></span> personas ya rechazaron la invitación.</li>
+                                        <% if (analytics.costoPorPersonaARS > 0) { %>
+                                        <li><strong>Presupuesto confirmado:</strong> <span data-stat="costo-confirmados"><%= formatCurrency(analytics.costoConfirmadosARS) %></span> con un costo unitario de <span data-stat="costo-persona"><%= formatCurrency(analytics.costoPorPersonaARS) %></span>.</li>
+                                        <% } %>
+                                        <% if (analytics.capacidadPlaneada > 0) { %>
+                                        <li><strong>Cupos restantes:</strong> <span data-stat="capacidad-restante-evento"><%= formatInteger(analytics.capacidadRestanteEvento) %></span> lugares disponibles dentro de la capacidad planificada (<span data-stat="capacidad-planeada"><%= formatInteger(analytics.capacidadPlaneada) %></span>).</li>
+                                        <% } %>
+                                    </ul>
+                                </article>
+                            </section>
                         </div>
                         <div class="table-container">
                             <table>
@@ -869,6 +1214,12 @@
                         </div>
                     </header>
                     <div class="section-body">
+                        <%
+                            const aiPublic = ai || (locals.ai || {});
+                            const aiMissingVars = Array.isArray(aiPublic.missing) ? aiPublic.missing : [];
+                            const aiEndpointLabel = aiPublic.endpoint ? aiPublic.endpoint : 'Valor por defecto';
+                            const aiLocaleLabel = aiPublic.defaultLocale || 'es-AR';
+                        %>
                         <div class="cards-grid">
                             <article id="herramientas-accesos" class="card tools-card" data-card-anchor>
                                 <h3>Accesos rápidos</h3>
@@ -891,6 +1242,38 @@
                                             Borrar todos los invitados
                                         </button>
                                     </form>
+                                </div>
+                            </article>
+                            <article id="configuracion-ia" class="card tools-card" data-card-anchor>
+                                <h3>Configuración de IA</h3>
+                                <p>Verificá el estado de la integración con el asistente inteligente del panel.</p>
+                                <div class="ai-status" data-ai-config="<%= aiPublic.isConfigured ? 'ok' : 'missing' %>">
+                                    <p class="ai-status__headline">
+                                        <strong>Estado:</strong>
+                                        <span><%= aiPublic.isConfigured ? 'Configuración correcta' : 'Faltan credenciales' %></span>
+                                    </p>
+                                    <% if (!aiPublic.isConfigured && aiMissingVars.length) { %>
+                                        <p class="ai-status__warning">Variables faltantes: <code><%= aiMissingVars.join(', ') %></code>.</p>
+                                    <% } %>
+                                    <dl class="ai-status__details">
+                                        <div>
+                                            <dt>Proveedor</dt>
+                                            <dd><%= aiPublic.provider || 'No definido' %></dd>
+                                        </div>
+                                        <div>
+                                            <dt>Modelo</dt>
+                                            <dd><%= aiPublic.model || 'No definido' %></dd>
+                                        </div>
+                                        <div>
+                                            <dt>Endpoint</dt>
+                                            <dd><%= aiEndpointLabel %></dd>
+                                        </div>
+                                        <div>
+                                            <dt>Locale</dt>
+                                            <dd><%= aiLocaleLabel %></dd>
+                                        </div>
+                                    </dl>
+                                    <p class="ai-status__hint">Editá <code>config/ai.js</code> y configurá las variables <code>AI_API_KEY</code> y <code>AI_MODEL</code> para habilitar la IA.</p>
                                 </div>
                             </article>
                         </div>
@@ -1037,13 +1420,20 @@
         const overviewLabel = overviewContainer ? overviewContainer.querySelector('[data-overview-label]') : null;
         const overviewTermino = overviewContainer ? overviewContainer.querySelector('[data-overview-termino]') : null;
         const overviewEstado = overviewContainer ? overviewContainer.querySelector('[data-overview-estado]') : null;
-        const statElements = {
-            grupos: document.querySelector('[data-stat="grupos"]'),
-            personas: document.querySelector('[data-stat="personas"]'),
-            confirmados: document.querySelector('[data-stat="confirmados"]'),
-            pendientes: document.querySelector('[data-stat="pendientes"]'),
-            rechazados: document.querySelector('[data-stat="rechazados"]')
+        const statElements = {};
+        document.querySelectorAll('[data-stat]').forEach((element) => {
+            const key = element.getAttribute('data-stat');
+            if (!key) return;
+            if (!statElements[key]) {
+                statElements[key] = [];
+            }
+            statElements[key].push(element);
+        });
+        const chartElements = {
+            grupos: document.getElementById('chart-estado-grupos'),
+            personas: document.getElementById('chart-estado-personas')
         };
+        const chartInstances = {};
 
         const TEMP_ALERT_IDS = {
             success: 'copy-link-success',
@@ -1067,15 +1457,10 @@
             estadoSeleccionado,
             baseUrl,
             invitados,
-            stats: {
-                totalGrupos: invitados.length,
-                totalPersonas: totalInvitados,
-                confirmados,
-                pendientes,
-                rechazados
-            },
+            stats: typeof stats !== 'undefined' ? stats : null,
             alerts: typeof alerts !== 'undefined' ? alerts : [],
-            importSummary: typeof importSummary !== 'undefined' ? importSummary : null
+            importSummary: typeof importSummary !== 'undefined' ? importSummary : null,
+            ai: typeof ai !== 'undefined' ? ai : null
         }) %>;
 
         const state = {
@@ -1086,6 +1471,143 @@
             baseUrl: initialState.baseUrl || window.location.origin,
             importSummary: initialState.importSummary || null
         };
+
+        const numberFormatter = new Intl.NumberFormat('es-AR');
+        const decimalFormatter = new Intl.NumberFormat('es-AR', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+        const percentFormatter = new Intl.NumberFormat('es-AR', { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+        const currencyFormatter = new Intl.NumberFormat('es-AR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+        const toNumeric = (value) => {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : 0;
+        };
+
+        function setStatValue(key, value, formatter) {
+            const elements = statElements[key];
+            if (!elements || elements.length === 0) return;
+            const formatted = formatter(value);
+            elements.forEach((el) => {
+                el.textContent = formatted;
+            });
+        }
+
+        function formatIntegerValue(value) {
+            return numberFormatter.format(toNumeric(value));
+        }
+
+        function formatDecimalValue(value) {
+            return decimalFormatter.format(toNumeric(value));
+        }
+
+        function formatPercentValue(value) {
+            return `${percentFormatter.format(toNumeric(value))}%`;
+        }
+
+        function formatCurrencyValue(value) {
+            return `$ (ARS) ${currencyFormatter.format(toNumeric(value))}`;
+        }
+
+        function updateCharts(stats) {
+            if (!window.Chart) return;
+            const gruposData = [
+                toNumeric(stats?.distribucionGrupos?.confirmado),
+                toNumeric(stats?.distribucionGrupos?.pendiente),
+                toNumeric(stats?.distribucionGrupos?.rechazado)
+            ];
+            const personasData = [
+                toNumeric(stats?.distribucionPersonas?.confirmadas),
+                toNumeric(stats?.distribucionPersonas?.pendientes),
+                toNumeric(stats?.distribucionPersonas?.rechazadas)
+            ];
+
+            if (chartElements.grupos) {
+                if (!chartInstances.grupos) {
+                    chartInstances.grupos = new window.Chart(chartElements.grupos.getContext('2d'), {
+                        type: 'bar',
+                        data: {
+                            labels: ['Confirmadas', 'Pendientes', 'Rechazadas'],
+                            datasets: [{
+                                label: 'Cantidad de invitaciones',
+                                data: gruposData,
+                                backgroundColor: ['#0d6efd', '#6c757d', '#dc3545']
+                            }]
+                        },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            plugins: {
+                                legend: {
+                                    display: true,
+                                    labels: { font: { family: 'inherit' } }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Distribución de invitaciones (grupos)',
+                                    font: { size: 16, family: 'inherit' }
+                                }
+                            },
+                            scales: {
+                                y: {
+                                    beginAtZero: true,
+                                    title: { display: true, text: 'Cantidad de invitaciones' }
+                                },
+                                x: {
+                                    title: { display: true, text: 'Estado' }
+                                }
+                            }
+                        }
+                    });
+                } else {
+                    chartInstances.grupos.data.datasets[0].data = gruposData;
+                    chartInstances.grupos.update();
+                }
+            }
+
+            if (chartElements.personas) {
+                if (!chartInstances.personas) {
+                    chartInstances.personas = new window.Chart(chartElements.personas.getContext('2d'), {
+                        type: 'doughnut',
+                        data: {
+                            labels: ['Personas confirmadas', 'Personas pendientes', 'Personas que no asistirán'],
+                            datasets: [{
+                                label: 'Cantidad de personas',
+                                data: personasData,
+                                backgroundColor: ['#198754', '#ffc107', '#dc3545']
+                            }]
+                        },
+                        options: {
+                            responsive: true,
+                            maintainAspectRatio: false,
+                            plugins: {
+                                legend: {
+                                    display: true,
+                                    position: 'bottom',
+                                    labels: { font: { family: 'inherit' } }
+                                },
+                                title: {
+                                    display: true,
+                                    text: 'Distribución de personas según respuesta',
+                                    font: { size: 16, family: 'inherit' }
+                                },
+                                tooltip: {
+                                    callbacks: {
+                                        label: (context) => {
+                                            const value = toNumeric(context.raw);
+                                            const total = personasData.reduce((sum, current) => sum + current, 0);
+                                            const percentage = total > 0 ? Math.round((value / total) * 1000) / 10 : 0;
+                                            return `${context.label}: ${numberFormatter.format(value)} (${percentage.toFixed(1)}%)`;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    });
+                } else {
+                    chartInstances.personas.data.datasets[0].data = personasData;
+                    chartInstances.personas.update();
+                }
+            }
+        }
 
         function getEmptyResultsMessage() {
             const terminoActual = (state.filters?.termino || '').trim();
@@ -1269,11 +1791,27 @@
 
         function renderStats(stats) {
             if (!stats) return;
-            if (statElements.grupos) statElements.grupos.textContent = stats.totalGrupos ?? 0;
-            if (statElements.personas) statElements.personas.textContent = stats.totalPersonas ?? 0;
-            if (statElements.confirmados) statElements.confirmados.textContent = stats.confirmados ?? 0;
-            if (statElements.pendientes) statElements.pendientes.textContent = stats.pendientes ?? 0;
-            if (statElements.rechazados) statElements.rechazados.textContent = stats.rechazados ?? 0;
+            setStatValue('grupos', stats.totalGrupos, formatIntegerValue);
+            setStatValue('personas', stats.totalPersonas, formatIntegerValue);
+            setStatValue('confirmados', stats.confirmados, formatIntegerValue);
+            setStatValue('pendientes', stats.pendientes, formatIntegerValue);
+            setStatValue('rechazados', stats.rechazados, formatIntegerValue);
+            setStatValue('personas-rechazadas', stats.personasRechazadas, formatIntegerValue);
+            setStatValue('porcentaje-confirmacion', stats.porcentajeConfirmacion, formatPercentValue);
+            setStatValue('porcentaje-respuesta', stats.porcentajeRespuesta, formatPercentValue);
+            setStatValue('grupos-respondieron', stats.gruposRespondieron, formatIntegerValue);
+            setStatValue('personas-pendientes', stats.personasPendientes, formatIntegerValue);
+            setStatValue('capacidad-disponible', stats.capacidadDisponible, formatIntegerValue);
+            setStatValue('grupos-parciales', stats.gruposConAsistenciaParcial, formatIntegerValue);
+            setStatValue('promedio-personas', stats.promedioPersonasGrupo, formatDecimalValue);
+            setStatValue('promedio-asistentes-grupo', stats.promedioAsistentesPorGrupoConfirmado, formatDecimalValue);
+            setStatValue('costo-persona', stats.costoPorPersonaARS, formatCurrencyValue);
+            setStatValue('costo-confirmados', stats.costoConfirmadosARS, formatCurrencyValue);
+            setStatValue('costo-pendiente', stats.costoPendienteARS, formatCurrencyValue);
+            setStatValue('capacidad-planeada', stats.capacidadPlaneada, formatIntegerValue);
+            setStatValue('capacidad-restante-evento', stats.capacidadRestanteEvento, formatIntegerValue);
+            setStatValue('capacidad-ocupada-porcentaje', stats.porcentajeOcupacionPlaneada, formatPercentValue);
+            updateCharts(stats);
         }
 
         function updateFormFields(filters) {
@@ -1489,7 +2027,9 @@
         }
 
         updateFormFields(state.filters);
-        renderStats(initialState.stats);
+        if (initialState.stats) {
+            renderStats(initialState.stats);
+        }
         renderTable(initialState.invitados, state.baseUrl);
         updateSearchSummary(initialState.invitados);
         renderOverview(state.filters, initialState.invitados);


### PR DESCRIPTION
## Summary
- add a dedicated `config/ai.js` module to centralize environment-based AI configuration and surface its status in the admin panel
- compute extended attendance analytics on the server and expose them to the dashboard API responses
- redesign the admin analytics section with richer metric cards, labelled charts, AI status messaging, and document the setup in the README

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68e12ae3dba0832b8918b4b23852ff7e